### PR TITLE
Don't push SonarQube as Dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
           registries: 311462405659
 
       - name: Push Container
+        if: github.actor != 'dependabot[bot]'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           FILE_SERVICE_ECR_REPOSITORY: file_service


### PR DESCRIPTION
Dependabot doesn't have permission to push to ECR

#patch